### PR TITLE
No forzar tmdb_active

### DIFF
--- a/plugin.video.alfa/platformcode/launcher.py
+++ b/plugin.video.alfa/platformcode/launcher.py
@@ -151,7 +151,7 @@ def run(item=None):
     item = monkey_patch_modules(item)
 
     try:
-        if not config.get_setting('tmdb_active'):
+        if config.get_setting('tmdb_active') is None:
             config.set_setting('tmdb_active', True)
 
         # Special action for playing a video from the library


### PR DESCRIPTION
Actualmente si lo pones a false en al config se pone si o si a True. Entiendo que esto es simplemente par ala inicialización si no tiene valor, por lo que con "si no existe" respetará el valor configurado y, además, se inicializará si no existía.